### PR TITLE
feat: Defer organization listing access to the host owner authorizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "php": "^8.2",
     "laravel/framework": "^11.0|^12.0",
     "whilesmart/eloquent-roles": "dev-main",
+    "whilesmart/eloquent-owner-access": "^1.0",
     "cviebrock/eloquent-sluggable": "^12.0",
     "zircote/swagger-php": "^5.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24cde150ba2701954574a0193f4bcde7",
+    "content-hash": "d434db07d5dc9661cf78de75178beae2",
     "packages": [
         {
             "name": "brick/math",
@@ -6105,6 +6105,57 @@
             "time": "2022-06-03T18:03:27+00:00"
         },
         {
+            "name": "whilesmart/eloquent-owner-access",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/whilesmartphp/eloquent-owner-access.git",
+                "reference": "3edbda3296eca3bbb141b7f8368fd482308677b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/whilesmartphp/eloquent-owner-access/zipball/3edbda3296eca3bbb141b7f8368fd482308677b0",
+                "reference": "3edbda3296eca3bbb141b7f8368fd482308677b0",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^11.0|^12.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.22",
+                "orchestra/testbench": "^9.0|^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Whilesmart\\OwnerAccess\\OwnerAccessServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Whilesmart\\OwnerAccess\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Whilesmart Team"
+                }
+            ],
+            "description": "Pluggable polymorphic owner authorization for Laravel packages with owner_type/owner_id columns. Lets host apps decide who can see and modify owner-scoped records without coupling the underlying packages to a specific tenancy model.",
+            "support": {
+                "issues": "https://github.com/whilesmartphp/eloquent-owner-access/issues",
+                "source": "https://github.com/whilesmartphp/eloquent-owner-access/tree/v1.0.0"
+            },
+            "time": "2026-06-10T17:45:50+00:00"
+        },
+        {
             "name": "whilesmart/eloquent-roles",
             "version": "dev-main",
             "source": {
@@ -9107,5 +9158,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Http/Controllers/OrganizationController.php
+++ b/src/Http/Controllers/OrganizationController.php
@@ -10,10 +10,13 @@ use Whilesmart\Organizations\Events\OrganizationCreatedEvent;
 use Whilesmart\Organizations\Events\OrganizationUpdatedEvent;
 use Whilesmart\Organizations\Interfaces\OrganizationControllerInterface;
 use Whilesmart\Organizations\Models\Organization;
+use Whilesmart\OwnerAccess\Concerns\AuthorizesOwnerController;
 use Whilesmart\Roles\Models\RoleAssignment;
 
 class OrganizationController extends ApiController implements OrganizationControllerInterface
 {
+    use AuthorizesOwnerController;
+
     public function index(Request $request, ?string $workspaceId = null): JsonResponse
     {
         $query = Organization::query();
@@ -33,6 +36,10 @@ class OrganizationController extends ApiController implements OrganizationContro
 
         $user = $request->user();
         $organization_ids = $user->roleAssignments()->where('context_type', 'organization')->pluck('context_id')->toArray();
+
+        // Defer additional owner-based scoping to the host application's
+        // OwnerAuthorizer (no-op by default via AllowAllAuthorizer).
+        $this->scopeAccessibleOwners($query, $user);
 
         $per_page = $request->get('per_page', 10);
         $organizations = $query->wherein('id', $organization_ids)->paginate($per_page);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -511,6 +511,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
     protected function getPackageProviders($app)
     {
         return [
+            'Whilesmart\OwnerAccess\OwnerAccessServiceProvider',
             'Whilesmart\Organizations\OrganizationsServiceProvider',
         ];
     }


### PR DESCRIPTION
## What
- Adds `whilesmart/eloquent-owner-access` as a dependency.
- `OrganizationController@index` now routes its query through the host application's `OwnerAuthorizer` via `AuthorizesOwnerController::scopeAccessibleOwners()`.

## Why
Lets a consuming app scope organizations by their polymorphic owner (for example, by workspace) without this package hard-coding a tenancy model.

## Backward compatibility
No-op by default: with the package's `AllowAllAuthorizer`, the query is untouched. The existing role-based org-membership scoping and per-record authorization on show/update/destroy are unchanged.