### PR TITLE
feat: Make organization APIs customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.0] - 2026-08-01
+- Allow applications to configure organization routes, models, resources, responses, and controllers
+- Dispatch the existing organization deleted event after successful deletion
+
 ## [1.1.0] - 2026-06-11
 - Organization listing now defers owner-based scoping to the host application's owner authorizer, enabling workspace-scoped access without changing default behaviour.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [1.2.0] - 2026-08-01
 - Allow applications to configure organization routes, models, resources, responses, and controllers
 - Dispatch the existing organization deleted event after successful deletion
+- Allow applications to transform organization requests and responses with typed hooks
+- Dispatch member added and removed events after successful role changes
 
 ## [1.1.0] - 2026-06-11
 - Organization listing now defers owner-based scoping to the host application's owner authorizer, enabling workspace-scoped access without changing default behaviour.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Applications can keep package-owned routes while replacing only the behavior the
 'model' => \App\Models\Organization::class,
 'resource' => \App\Http\Resources\OrganizationResource::class,
 'response_formatter' => \App\Http\Responses\OrganizationResponseFormatter::class,
+'hooks' => [\App\Organizations\OrganizationHook::class],
 'route_actions' => ['index', 'store', 'show'],
 'route_write_middleware' => ['workspace.write'],
 'register_workspace_routes' => false,
@@ -50,6 +51,14 @@ Applications can keep package-owned routes while replacing only the behavior the
 The custom model and resource extend their package defaults. The response formatter implements
 the package contract. The custom controller remains the final escape hatch. Write middleware
 applies to create, update, delete, and member write routes that remain enabled.
+
+Hooks implement `OrganizationHook`. Their `before` method receives the request before validation,
+and their `after` method receives responses returned by the controller. Both methods receive an
+`OrganizationAction` value identifying the operation. Hooks are resolved through the container.
+
+Successful member role changes dispatch `OrganizationMemberAddedEvent` and
+`OrganizationMemberRemovedEvent`. Each event contains the organization, affected member model,
+and role.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,24 @@ Optionally publish the configuration file:
 php artisan vendor:publish --tag="organizations-config"
 ```
 
-### Publish Routes
+### Customize Routes
 
-To customize the API routes:
+Applications can keep package-owned routes while replacing only the behavior they need:
 
-```bash
-php artisan vendor:publish --tag="organizations-routes"
+```php
+'controller' => \App\Http\Controllers\OrganizationController::class,
+'model' => \App\Models\Organization::class,
+'resource' => \App\Http\Resources\OrganizationResource::class,
+'response_formatter' => \App\Http\Responses\OrganizationResponseFormatter::class,
+'route_actions' => ['index', 'store', 'show'],
+'route_write_middleware' => ['workspace.write'],
+'register_workspace_routes' => false,
+'register_member_routes' => false,
 ```
+
+The custom model and resource extend their package defaults. The response formatter implements
+the package contract. The custom controller remains the final escape hatch. Write middleware
+applies to create, update, delete, and member write routes that remain enabled.
 
 ## Usage
 
@@ -146,4 +157,3 @@ return [
 ## License
 
 The MIT License (MIT).
-

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "whilesmart/eloquent-organizations",
   "description": "Organization management package for Laravel applications",
-  "package-version": "1.1.0",
+  "package-version": "1.2.0",
   "keywords": [
     "laravel",
     "organization",

--- a/config/organizations.php
+++ b/config/organizations.php
@@ -30,6 +30,7 @@ return [
     'controller' => OrganizationController::class,
     'resource' => OrganizationResource::class,
     'response_formatter' => DefaultResponseFormatter::class,
+    'hooks' => [],
 
     /*
     |--------------------------------------------------------------------------

--- a/config/organizations.php
+++ b/config/organizations.php
@@ -1,5 +1,10 @@
 <?php
 
+use Whilesmart\Organizations\Http\Controllers\OrganizationController;
+use Whilesmart\Organizations\Http\Resources\OrganizationResource;
+use Whilesmart\Organizations\Models\Organization;
+use Whilesmart\Organizations\ResponseFormatters\DefaultResponseFormatter;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -8,6 +13,7 @@ return [
     */
     'user_model' => env('ORGANIZATIONS_USER_MODEL', 'App\\Models\\User'),
     'workspace_model' => env('ORGANIZATIONS_WORKSPACE_MODEL', 'App\\Models\\Workspace'),
+    'model' => Organization::class,
 
     /*
     |--------------------------------------------------------------------------
@@ -17,6 +23,13 @@ return [
     'register_routes' => env('ORGANIZATIONS_REGISTER_ROUTES', true),
     'route_prefix' => env('ORGANIZATIONS_ROUTE_PREFIX', ''),
     'route_middleware' => ['auth:sanctum'],
+    'route_write_middleware' => [],
+    'route_actions' => ['index', 'store', 'show', 'update', 'destroy'],
+    'register_workspace_routes' => true,
+    'register_member_routes' => true,
+    'controller' => OrganizationController::class,
+    'resource' => OrganizationResource::class,
+    'response_formatter' => DefaultResponseFormatter::class,
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/organizations.php
+++ b/routes/organizations.php
@@ -1,26 +1,27 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Whilesmart\Organizations\Http\Controllers\OrganizationController;
 
-/*
-|--------------------------------------------------------------------------
-| Organizations API Routes
-|--------------------------------------------------------------------------
-|
-| Here are the API routes for organization management. These routes are
-| automatically registered by the OrganizationsServiceProvider.
-|
-*/
+$controller = config('organizations.controller');
+$writeMiddleware = config('organizations.route_write_middleware', []);
 
-// Organization Management (workspace-scoped if enabled)
-Route::get('/workspaces/{workspaceId}/organizations', [OrganizationController::class, 'index']);
-Route::post('/workspaces/{workspaceId}/organizations', [OrganizationController::class, 'store']);
+if (config('organizations.register_workspace_routes', true)) {
+    Route::get('/workspaces/{workspaceId}/organizations', [$controller, 'index']);
+    Route::post('/workspaces/{workspaceId}/organizations', [$controller, 'store'])
+        ->middleware($writeMiddleware);
+}
 
-// Organization Management (standalone routes)
-Route::apiResource('/organizations', OrganizationController::class);
+$routes = Route::apiResource('/organizations', $controller)
+    ->only(config('organizations.route_actions'));
 
-// organization members
-Route::get('/organizations/{id}/members', [OrganizationController::class, 'getMembers']);
-Route::post('/organizations/{id}/members', [OrganizationController::class, 'addMember']);
-Route::delete('/organizations/{id}/members/{member_id}', [OrganizationController::class, 'removeMember']);
+if ($writeMiddleware !== []) {
+    $routes->middlewareFor(['store', 'update', 'destroy'], $writeMiddleware);
+}
+
+if (config('organizations.register_member_routes', true)) {
+    Route::get('/organizations/{id}/members', [$controller, 'getMembers']);
+    Route::post('/organizations/{id}/members', [$controller, 'addMember'])
+        ->middleware($writeMiddleware);
+    Route::delete('/organizations/{id}/members/{member_id}', [$controller, 'removeMember'])
+        ->middleware($writeMiddleware);
+}

--- a/src/Concerns/RunsOrganizationHooks.php
+++ b/src/Concerns/RunsOrganizationHooks.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Whilesmart\Organizations\Concerns;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use Whilesmart\Organizations\Contracts\OrganizationHook;
+use Whilesmart\Organizations\Enums\OrganizationAction;
+
+trait RunsOrganizationHooks
+{
+    protected function runBeforeHooks(Request $request, OrganizationAction $action): Request
+    {
+        foreach ($this->organizationHooks() as $hook) {
+            $request = $hook->before($request, $action);
+        }
+
+        return $request;
+    }
+
+    protected function runAfterHooks(
+        Request $request,
+        JsonResponse $response,
+        OrganizationAction $action,
+    ): JsonResponse {
+        foreach ($this->organizationHooks() as $hook) {
+            $response = $hook->after($request, $response, $action);
+        }
+
+        return $response;
+    }
+
+    /** @return list<OrganizationHook> */
+    private function organizationHooks(): array
+    {
+        return array_map(function (string $hookClass): OrganizationHook {
+            $hook = app()->make($hookClass);
+
+            if (! $hook instanceof OrganizationHook) {
+                throw new InvalidArgumentException(
+                    'Configured organization hooks must implement '.OrganizationHook::class.'.',
+                );
+            }
+
+            return $hook;
+        }, config('organizations.hooks', []));
+    }
+}

--- a/src/Contracts/OrganizationHook.php
+++ b/src/Contracts/OrganizationHook.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Whilesmart\Organizations\Contracts;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Whilesmart\Organizations\Enums\OrganizationAction;
+
+interface OrganizationHook
+{
+    public function before(Request $request, OrganizationAction $action): Request;
+
+    public function after(Request $request, JsonResponse $response, OrganizationAction $action): JsonResponse;
+}

--- a/src/Contracts/ResponseFormatter.php
+++ b/src/Contracts/ResponseFormatter.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Whilesmart\Organizations\Contracts;
+
+use Illuminate\Http\JsonResponse;
+
+interface ResponseFormatter
+{
+    public function success(mixed $data = null, string $message = 'Operation successful', int $statusCode = 200): JsonResponse;
+
+    public function failure(string $message = 'Operation failed', int $statusCode = 400, array $errors = []): JsonResponse;
+}

--- a/src/Enums/OrganizationAction.php
+++ b/src/Enums/OrganizationAction.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Whilesmart\Organizations\Enums;
+
+enum OrganizationAction: string
+{
+    case INDEX = 'index';
+    case STORE = 'store';
+    case SHOW = 'show';
+    case UPDATE = 'update';
+    case DESTROY = 'destroy';
+    case ADD_MEMBER = 'addMember';
+    case GET_MEMBERS = 'getMembers';
+    case REMOVE_MEMBER = 'removeMember';
+}

--- a/src/Events/OrganizationMemberAddedEvent.php
+++ b/src/Events/OrganizationMemberAddedEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Whilesmart\Organizations\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Whilesmart\Organizations\Models\Organization;
+
+class OrganizationMemberAddedEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Organization $organization,
+        public Model $member,
+        public string $role,
+    ) {}
+}

--- a/src/Events/OrganizationMemberRemovedEvent.php
+++ b/src/Events/OrganizationMemberRemovedEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Whilesmart\Organizations\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Whilesmart\Organizations\Models\Organization;
+
+class OrganizationMemberRemovedEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Organization $organization,
+        public Model $member,
+        public string $role,
+    ) {}
+}

--- a/src/Http/Controllers/ApiController.php
+++ b/src/Http/Controllers/ApiController.php
@@ -4,6 +4,7 @@ namespace Whilesmart\Organizations\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller as BaseController;
+use Whilesmart\Organizations\Contracts\ResponseFormatter;
 use Whilesmart\Organizations\Interfaces\ApiControllerInterface;
 
 class ApiController extends BaseController implements ApiControllerInterface
@@ -15,11 +16,7 @@ class ApiController extends BaseController implements ApiControllerInterface
      */
     public function success($data = null, string $message = 'Operation successful', int $statusCode = 200): JsonResponse
     {
-        return response()->json([
-            'success' => true,
-            'message' => $message,
-            'data' => $data,
-        ], $statusCode);
+        return app(ResponseFormatter::class)->success($data, $message, $statusCode);
     }
 
     /**
@@ -27,10 +24,6 @@ class ApiController extends BaseController implements ApiControllerInterface
      */
     public function failure(string $message = 'Operation failed', int $statusCode = 400, array $errors = []): JsonResponse
     {
-        return response()->json([
-            'success' => false,
-            'message' => $message,
-            'errors' => $errors,
-        ], $statusCode);
+        return app(ResponseFormatter::class)->failure($message, $statusCode, $errors);
     }
 }

--- a/src/Http/Controllers/OrganizationController.php
+++ b/src/Http/Controllers/OrganizationController.php
@@ -7,8 +7,12 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
+use Whilesmart\Organizations\Concerns\RunsOrganizationHooks;
+use Whilesmart\Organizations\Enums\OrganizationAction;
 use Whilesmart\Organizations\Events\OrganizationCreatedEvent;
 use Whilesmart\Organizations\Events\OrganizationDeletedEvent;
+use Whilesmart\Organizations\Events\OrganizationMemberAddedEvent;
+use Whilesmart\Organizations\Events\OrganizationMemberRemovedEvent;
 use Whilesmart\Organizations\Events\OrganizationUpdatedEvent;
 use Whilesmart\Organizations\Interfaces\OrganizationControllerInterface;
 use Whilesmart\Organizations\Models\Organization;
@@ -17,9 +21,20 @@ use Whilesmart\Roles\Models\RoleAssignment;
 
 class OrganizationController extends ApiController implements OrganizationControllerInterface
 {
-    use AuthorizesOwnerController;
+    use AuthorizesOwnerController, RunsOrganizationHooks;
 
     public function index(Request $request, ?string $workspaceId = null): JsonResponse
+    {
+        $request = $this->runBeforeHooks($request, OrganizationAction::INDEX);
+
+        return $this->runAfterHooks(
+            $request,
+            $this->indexResponse($request, $workspaceId),
+            OrganizationAction::INDEX,
+        );
+    }
+
+    private function indexResponse(Request $request, ?string $workspaceId = null): JsonResponse
     {
         $model = $this->model();
         $query = $model::query();
@@ -51,6 +66,17 @@ class OrganizationController extends ApiController implements OrganizationContro
     }
 
     public function store(Request $request, ?string $workspaceId = null): JsonResponse
+    {
+        $request = $this->runBeforeHooks($request, OrganizationAction::STORE);
+
+        return $this->runAfterHooks(
+            $request,
+            $this->storeResponse($request, $workspaceId),
+            OrganizationAction::STORE,
+        );
+    }
+
+    private function storeResponse(Request $request, ?string $workspaceId = null): JsonResponse
     {
         $user = $request->user();
         $validator = Validator::make($request->all(), [
@@ -117,6 +143,13 @@ class OrganizationController extends ApiController implements OrganizationContro
 
     public function show(Request $request, string $id): JsonResponse
     {
+        $request = $this->runBeforeHooks($request, OrganizationAction::SHOW);
+
+        return $this->runAfterHooks($request, $this->showResponse($request, $id), OrganizationAction::SHOW);
+    }
+
+    private function showResponse(Request $request, string $id): JsonResponse
+    {
         $model = $this->model();
         $organization = $model::find($id);
         if ($organization) {
@@ -133,6 +166,13 @@ class OrganizationController extends ApiController implements OrganizationContro
     }
 
     public function destroy(Request $request, string $id): JsonResponse
+    {
+        $request = $this->runBeforeHooks($request, OrganizationAction::DESTROY);
+
+        return $this->runAfterHooks($request, $this->destroyResponse($request, $id), OrganizationAction::DESTROY);
+    }
+
+    private function destroyResponse(Request $request, string $id): JsonResponse
     {
 
         $model = $this->model();
@@ -155,6 +195,13 @@ class OrganizationController extends ApiController implements OrganizationContro
 
     public function addMember(Request $request, string $id): JsonResponse
     {
+        $request = $this->runBeforeHooks($request, OrganizationAction::ADD_MEMBER);
+
+        return $this->runAfterHooks($request, $this->addMemberResponse($request, $id), OrganizationAction::ADD_MEMBER);
+    }
+
+    private function addMemberResponse(Request $request, string $id): JsonResponse
+    {
         $data = $request->validate([
             'email' => 'required',
             'role' => 'nullable|string|in:member,admin',
@@ -173,7 +220,9 @@ class OrganizationController extends ApiController implements OrganizationContro
                     if ($user_to_invite->hasRole('member', 'organization', $id) || $user_to_invite->hasRole('admin', 'organization', $id)) {
                         return $this->failure('This person has already been invited to this organization.', 400);
                     } else {
-                        $user_to_invite->assignRole($data['role'], 'organization', $id);
+                        $role = $data['role'] ?? 'member';
+                        $user_to_invite->assignRole($role, 'organization', $id);
+                        OrganizationMemberAddedEvent::dispatch($organization, $user_to_invite, $role);
 
                         // todo: Send a notification or email to this user.
                         return $this->success(message: 'Member Added');
@@ -191,6 +240,13 @@ class OrganizationController extends ApiController implements OrganizationContro
     }
 
     public function getMembers(Request $request, string $id): JsonResponse
+    {
+        $request = $this->runBeforeHooks($request, OrganizationAction::GET_MEMBERS);
+
+        return $this->runAfterHooks($request, $this->getMembersResponse($request, $id), OrganizationAction::GET_MEMBERS);
+    }
+
+    private function getMembersResponse(Request $request, string $id): JsonResponse
     {
 
         $model = $this->model();
@@ -220,6 +276,17 @@ class OrganizationController extends ApiController implements OrganizationContro
 
     public function removeMember(Request $request, string $id, $member_id): JsonResponse
     {
+        $request = $this->runBeforeHooks($request, OrganizationAction::REMOVE_MEMBER);
+
+        return $this->runAfterHooks(
+            $request,
+            $this->removeMemberResponse($request, $id, $member_id),
+            OrganizationAction::REMOVE_MEMBER,
+        );
+    }
+
+    private function removeMemberResponse(Request $request, string $id, $member_id): JsonResponse
+    {
         $model = $this->model();
         $organization = $model::find($id);
         if ($organization) {
@@ -234,17 +301,21 @@ class OrganizationController extends ApiController implements OrganizationContro
                         return $this->failure('You cannot remove this member from this organization.', 403);
                     }
 
-                    if ($member->hasRole('member', 'organization', $id) || $user->hasRole('admin', 'organization', $id)) {
+                    if ($member->hasRole('member', 'organization', $id) || $member->hasRole('admin', 'organization', $id)) {
                         // ensure user is not trying to remove himself
                         if ($user->id == $member->id) {
                             return $this->failure(message: "You can't remove yourself");
                         }
 
                         if ($member->hasRole('member', 'organization', $id)) {
+                            $role = 'member';
                             $member->removeRole('member', 'organization', $id);
                         } else {
+                            $role = 'admin';
                             $member->removeRole('admin', 'organization', $id);
                         }
+
+                        OrganizationMemberRemovedEvent::dispatch($organization, $member, $role);
 
                         // todo: Send a notification or email to this user.
                         return $this->success(message: 'Member Deleted');
@@ -264,6 +335,17 @@ class OrganizationController extends ApiController implements OrganizationContro
     }
 
     public function update(Request $request, string $id, ?string $workspaceId = null): JsonResponse
+    {
+        $request = $this->runBeforeHooks($request, OrganizationAction::UPDATE);
+
+        return $this->runAfterHooks(
+            $request,
+            $this->updateResponse($request, $id, $workspaceId),
+            OrganizationAction::UPDATE,
+        );
+    }
+
+    private function updateResponse(Request $request, string $id, ?string $workspaceId = null): JsonResponse
     {
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',

--- a/src/Http/Controllers/OrganizationController.php
+++ b/src/Http/Controllers/OrganizationController.php
@@ -4,9 +4,11 @@ namespace Whilesmart\Organizations\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Whilesmart\Organizations\Events\OrganizationCreatedEvent;
+use Whilesmart\Organizations\Events\OrganizationDeletedEvent;
 use Whilesmart\Organizations\Events\OrganizationUpdatedEvent;
 use Whilesmart\Organizations\Interfaces\OrganizationControllerInterface;
 use Whilesmart\Organizations\Models\Organization;
@@ -19,7 +21,8 @@ class OrganizationController extends ApiController implements OrganizationContro
 
     public function index(Request $request, ?string $workspaceId = null): JsonResponse
     {
-        $query = Organization::query();
+        $model = $this->model();
+        $query = $model::query();
 
         if ($workspaceId && config('organizations.workspace_scoped', true)) {
             $query->where('workspace_id', $workspaceId);
@@ -44,7 +47,7 @@ class OrganizationController extends ApiController implements OrganizationContro
         $per_page = $request->get('per_page', 10);
         $organizations = $query->wherein('id', $organization_ids)->paginate($per_page);
 
-        return $this->success($organizations);
+        return $this->success($this->resourcePaginator($organizations, $request));
     }
 
     public function store(Request $request, ?string $workspaceId = null): JsonResponse
@@ -94,12 +97,13 @@ class OrganizationController extends ApiController implements OrganizationContro
             $organizationData['workspace_id'] = $workspaceId;
         }
 
-        $organization = Organization::where('owner_type', config('organizations.user_model'))->where('owner_id', $user->id)->where('name', $request->get('name'))->first();
+        $model = $this->model();
+        $organization = $model::where('owner_type', config('organizations.user_model'))->where('owner_id', $user->id)->where('name', $request->get('name'))->first();
         if ($organization) {
             return $this->failure('Organization name already exists.', 400);
         }
 
-        $organization = Organization::create($organizationData);
+        $organization = $model::create($organizationData);
         // assign this user the owner role
 
         $user->assignRole('owner', 'organization', $organization->id);
@@ -107,18 +111,19 @@ class OrganizationController extends ApiController implements OrganizationContro
         $organization->refresh();
         OrganizationCreatedEvent::dispatch($organization);
 
-        return $this->success($organization, 'Organization Created', 201);
+        return $this->success($this->resource($organization, $request), 'Organization Created', 201);
 
     }
 
     public function show(Request $request, string $id): JsonResponse
     {
-        $organization = Organization::find($id);
+        $model = $this->model();
+        $organization = $model::find($id);
         if ($organization) {
             $user = $request->user();
             // check if I am a member of this organization
             if ($user->hasRole('owner', 'organization', $id) || $user->hasRole('admin', 'organization', $id) || $user->hasRole('member', 'organization', $id)) {
-                return $this->success($organization);
+                return $this->success($this->resource($organization, $request));
             } else {
                 return $this->failure('You are not authorized to access this resource.', 403);
             }
@@ -130,12 +135,14 @@ class OrganizationController extends ApiController implements OrganizationContro
     public function destroy(Request $request, string $id): JsonResponse
     {
 
-        $organization = Organization::find($id);
+        $model = $this->model();
+        $organization = $model::find($id);
         if ($organization) {
             $user = $request->user();
             // check if I am the owner of this organization
             if ($user->hasRole('owner', 'organization', $id)) {
                 $organization->delete();
+                OrganizationDeletedEvent::dispatch($organization);
 
                 return $this->success(null, 'Organization Deleted');
             } else {
@@ -153,7 +160,8 @@ class OrganizationController extends ApiController implements OrganizationContro
             'role' => 'nullable|string|in:member,admin',
         ]);
 
-        $organization = Organization::find($id);
+        $model = $this->model();
+        $organization = $model::find($id);
         if ($organization) {
             $user_to_invite = config('organizations.user_model')::where('email', $data['email'])->first();
             if ($user_to_invite) {
@@ -185,7 +193,8 @@ class OrganizationController extends ApiController implements OrganizationContro
     public function getMembers(Request $request, string $id): JsonResponse
     {
 
-        $organization = Organization::find($id);
+        $model = $this->model();
+        $organization = $model::find($id);
         if ($organization) {
 
             $user = $request->user();
@@ -211,7 +220,8 @@ class OrganizationController extends ApiController implements OrganizationContro
 
     public function removeMember(Request $request, string $id, $member_id): JsonResponse
     {
-        $organization = Organization::find($id);
+        $model = $this->model();
+        $organization = $model::find($id);
         if ($organization) {
             $user = $request->user();
             // check if I am an admin of this organization
@@ -297,17 +307,56 @@ class OrganizationController extends ApiController implements OrganizationContro
                 $organizationData['workspace_id'] = $workspaceId;
             }
 
-            $organization = Organization::find($id);
+            $model = $this->model();
+            $organization = $model::find($id);
             if ($organization) {
                 $organization->update($organizationData);
                 OrganizationUpdatedEvent::dispatch($organization);
 
-                return $this->success($organization, 'Organization Updated', 200);
+                return $this->success($this->resource($organization, $request), 'Organization Updated', 200);
             } else {
                 return $this->failure('Organization not found', 404);
             }
         } else {
             return $this->failure('Unauthorized', 403);
         }
+    }
+
+    private function model(): string
+    {
+        $model = config('organizations.model', Organization::class);
+
+        if (! is_a($model, Organization::class, true)) {
+            throw new \InvalidArgumentException('The configured organization model must extend '.Organization::class.'.');
+        }
+
+        return $model;
+    }
+
+    private function resource(Organization $organization, Request $request): array
+    {
+        $resource = $this->resourceClass();
+
+        return (new $resource($organization))->resolve($request);
+    }
+
+    private function resourcePaginator($organizations, Request $request)
+    {
+        $organizations->setCollection(
+            $organizations->getCollection()->map(fn (Organization $organization) => $this->resource($organization, $request)),
+        );
+
+        return $organizations;
+    }
+
+    private function resourceClass(): string
+    {
+        $resource = config('organizations.resource');
+
+        if (! is_a($resource, JsonResource::class, true)) {
+            throw new \InvalidArgumentException('The configured organization resource must extend '.JsonResource::class.'.');
+        }
+
+        return $resource;
     }
 }

--- a/src/Http/Resources/OrganizationResource.php
+++ b/src/Http/Resources/OrganizationResource.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Whilesmart\Organizations\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class OrganizationResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/src/OrganizationsServiceProvider.php
+++ b/src/OrganizationsServiceProvider.php
@@ -4,12 +4,18 @@ namespace Whilesmart\Organizations;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Whilesmart\Organizations\Contracts\ResponseFormatter;
 
 class OrganizationsServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/organizations.php', 'organizations');
+
+        $this->app->bind(
+            ResponseFormatter::class,
+            fn ($app): ResponseFormatter => $app->make(config('organizations.response_formatter')),
+        );
     }
 
     public function boot(): void

--- a/src/ResponseFormatters/DefaultResponseFormatter.php
+++ b/src/ResponseFormatters/DefaultResponseFormatter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Whilesmart\Organizations\ResponseFormatters;
+
+use Illuminate\Http\JsonResponse;
+use Whilesmart\Organizations\Contracts\ResponseFormatter;
+
+class DefaultResponseFormatter implements ResponseFormatter
+{
+    public function success(mixed $data = null, string $message = 'Operation successful', int $statusCode = 200): JsonResponse
+    {
+        return response()->json([
+            'success' => true,
+            'message' => $message,
+            'data' => $data,
+        ], $statusCode);
+    }
+
+    public function failure(string $message = 'Operation failed', int $statusCode = 400, array $errors = []): JsonResponse
+    {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'errors' => $errors,
+        ], $statusCode);
+    }
+}

--- a/tests/RouteCustomizationTest.php
+++ b/tests/RouteCustomizationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
+use Orchestra\Testbench\TestCase as Orchestra;
+use Whilesmart\Organizations\Contracts\ResponseFormatter;
+use Whilesmart\Organizations\Http\Controllers\OrganizationController;
+use Whilesmart\Organizations\Http\Resources\OrganizationResource;
+use Whilesmart\Organizations\Models\Organization;
+use Whilesmart\Organizations\OrganizationsServiceProvider;
+
+class CustomOrganizationController extends OrganizationController
+{
+    public function index(Request $request, ?string $workspaceId = null): JsonResponse
+    {
+        $organization = new Organization;
+        $organization->forceFill(['name' => 'Example']);
+        $resource = config('organizations.resource');
+
+        return $this->success(new $resource($organization));
+    }
+}
+
+class CustomOrganizationResource extends OrganizationResource
+{
+    public function toArray($request): array
+    {
+        return [...parent::toArray($request), 'custom_resource' => true];
+    }
+}
+
+class CustomOrganizationResponseFormatter implements ResponseFormatter
+{
+    public function success(mixed $data = null, string $message = 'Operation successful', int $statusCode = 200): JsonResponse
+    {
+        return response()->json([
+            'success' => true,
+            'message' => $message,
+            'data' => $data,
+            'custom_formatter' => true,
+        ], $statusCode);
+    }
+
+    public function failure(string $message = 'Operation failed', int $statusCode = 400, array $errors = []): JsonResponse
+    {
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'errors' => $errors,
+            'custom_formatter' => true,
+        ], $statusCode);
+    }
+}
+
+class RouteCustomizationTest extends Orchestra
+{
+    protected function getPackageProviders($app): array
+    {
+        return [OrganizationsServiceProvider::class];
+    }
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('organizations.controller', CustomOrganizationController::class);
+        $app['config']->set('organizations.route_actions', ['index', 'store']);
+        $app['config']->set('organizations.route_write_middleware', ['organization-write']);
+        $app['config']->set('organizations.register_workspace_routes', false);
+        $app['config']->set('organizations.register_member_routes', false);
+        $app['config']->set('organizations.route_middleware', []);
+        $app['config']->set('organizations.resource', CustomOrganizationResource::class);
+        $app['config']->set('organizations.response_formatter', CustomOrganizationResponseFormatter::class);
+    }
+
+    public function test_it_configures_the_controller_routes_and_write_middleware(): void
+    {
+        $routes = $this->app['router']->getRoutes();
+        $index = $routes->getByName('organizations.index');
+        $store = $routes->getByName('organizations.store');
+
+        $this->assertInstanceOf(Route::class, $index);
+        $this->assertInstanceOf(Route::class, $store);
+        $this->assertSame(CustomOrganizationController::class.'@index', $index->getActionName());
+        $this->assertContains('organization-write', $store->gatherMiddleware());
+        $this->assertNull($routes->getByName('organizations.show'));
+
+        $uris = collect($routes)->map(fn (Route $route) => $route->uri())->all();
+
+        $this->assertNotContains('workspaces/{workspaceId}/organizations', $uris);
+        $this->assertNotContains('organizations/{id}/members', $uris);
+    }
+
+    public function test_it_uses_the_configured_resource_and_response_formatter(): void
+    {
+        $this->getJson('/organizations')
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Example')
+            ->assertJsonPath('data.custom_resource', true)
+            ->assertJsonPath('custom_formatter', true);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,16 +2,47 @@
 
 use Faker\Factory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\Attributes\WithMigration;
+use Whilesmart\Organizations\Contracts\OrganizationHook;
+use Whilesmart\Organizations\Enums\OrganizationAction;
 use Whilesmart\Organizations\Events\OrganizationCreatedEvent;
 use Whilesmart\Organizations\Events\OrganizationDeletedEvent;
+use Whilesmart\Organizations\Events\OrganizationMemberAddedEvent;
+use Whilesmart\Organizations\Events\OrganizationMemberRemovedEvent;
 use Whilesmart\Organizations\Events\OrganizationUpdatedEvent;
 use Whilesmart\Organizations\Models\Organization;
 use Whilesmart\Roles\Models\Role;
 use Workbench\App\Models\User;
+
+class TestOrganizationHook implements OrganizationHook
+{
+    public function before(Request $request, OrganizationAction $action): Request
+    {
+        if ($action === OrganizationAction::STORE) {
+            $request->merge([
+                'name' => 'Hooked Organization',
+                'type' => 'organization',
+                'email' => 'hooked@example.com',
+            ]);
+        }
+
+        return $request;
+    }
+
+    public function after(Request $request, JsonResponse $response, OrganizationAction $action): JsonResponse
+    {
+        $data = $response->getData(true);
+        $data['hook_action'] = $action->value;
+        $response->setData($data);
+
+        return $response;
+    }
+}
 
 #[WithMigration]
 class TestCase extends \Orchestra\Testbench\TestCase
@@ -111,6 +142,19 @@ class TestCase extends \Orchestra\Testbench\TestCase
                 'success' => false,
                 'message' => 'The given data was invalid.',
             ]);
+    }
+
+    public function test_hooks_transform_the_request_before_validation_and_the_final_response()
+    {
+        config()->set('organizations.hooks', [TestOrganizationHook::class]);
+
+        $user = $this->createUser();
+        $this->actingAs($user);
+
+        $this->postJson('/organizations', [])
+            ->assertCreated()
+            ->assertJsonPath('data.name', 'Hooked Organization')
+            ->assertJsonPath('hook_action', OrganizationAction::STORE->value);
     }
 
     public function test_show_organization()
@@ -259,6 +303,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     public function test_owner_can_add_member_to_organization()
     {
+        Event::fake();
+
         $owner = $this->createUser();
         $this->actingAs($owner);
 
@@ -281,10 +327,40 @@ class TestCase extends \Orchestra\Testbench\TestCase
             ]);
 
         $this->assertTrue($member->hasRole('member', 'organization', $organization->id));
+        Event::assertDispatched(
+            OrganizationMemberAddedEvent::class,
+            fn (OrganizationMemberAddedEvent $event): bool => $event->organization->is($organization)
+                && $event->member->is($member)
+                && $event->role === 'member',
+        );
+    }
+
+    public function test_member_role_defaults_to_member()
+    {
+        Event::fake();
+
+        $owner = $this->createUser();
+        $organization = $this->createOrganization($owner);
+        $owner->assignRole('owner', 'organization', $organization->id);
+        $member = $this->createUser(['email' => 'default-member@example.com']);
+
+        $this->actingAs($owner)
+            ->postJson("/organizations/{$organization->id}/members", [
+                'email' => $member->email,
+            ])
+            ->assertOk();
+
+        $this->assertTrue($member->hasRole('member', 'organization', $organization->id));
+        Event::assertDispatched(
+            OrganizationMemberAddedEvent::class,
+            fn (OrganizationMemberAddedEvent $event): bool => $event->role === 'member',
+        );
     }
 
     public function test_member_and_non_member_can_not_add_another_member_to_organization()
     {
+        Event::fake();
+
         $owner = $this->createUser();
 
         $organization = $this->createOrganization($owner);
@@ -308,10 +384,13 @@ class TestCase extends \Orchestra\Testbench\TestCase
         $response->assertStatus(403);
 
         $this->assertFalse($member2->hasRole('member', 'organization', $organization->id));
+        Event::assertNotDispatched(OrganizationMemberAddedEvent::class);
     }
 
     public function test_owner_can_remove_member_from_organization()
     {
+        Event::fake();
+
         $owner = $this->createUser();
         $this->actingAs($owner);
 
@@ -332,6 +411,12 @@ class TestCase extends \Orchestra\Testbench\TestCase
             ]);
 
         $this->assertFalse($member->hasRole('member', 'organization', $organization->id));
+        Event::assertDispatched(
+            OrganizationMemberRemovedEvent::class,
+            fn (OrganizationMemberRemovedEvent $event): bool => $event->organization->is($organization)
+                && $event->member->is($member)
+                && $event->role === 'member',
+        );
     }
 
     public function test_admin_can_remove_member_from_organization()
@@ -366,6 +451,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     public function test_member_and_non_member_can_not_remove_member_from_organization()
     {
+        Event::fake();
+
         $owner = $this->createUser();
 
         $organization = $this->createOrganization($owner);
@@ -387,6 +474,25 @@ class TestCase extends \Orchestra\Testbench\TestCase
         $response->assertStatus(403);
 
         $this->assertTrue($member2->hasRole('member', 'organization', $organization->id));
+        Event::assertNotDispatched(OrganizationMemberRemovedEvent::class);
+    }
+
+    public function test_admin_can_not_remove_a_user_without_an_organization_role()
+    {
+        Event::fake();
+
+        $owner = $this->createUser();
+        $organization = $this->createOrganization($owner);
+        $owner->assignRole('owner', 'organization', $organization->id);
+        $admin = $this->createUser(['email' => 'removing-admin@example.com']);
+        $admin->assignRole('admin', 'organization', $organization->id);
+        $unrelatedUser = $this->createUser(['email' => 'unrelated@example.com']);
+
+        $this->actingAs($admin)
+            ->deleteJson("/organizations/{$organization->id}/members/{$unrelatedUser->id}")
+            ->assertStatus(400);
+
+        Event::assertNotDispatched(OrganizationMemberRemovedEvent::class);
     }
 
     public function test_owner_get_list_of_members_in_organization()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Orchestra\Testbench\Attributes\WithMigration;
 use Whilesmart\Organizations\Events\OrganizationCreatedEvent;
+use Whilesmart\Organizations\Events\OrganizationDeletedEvent;
 use Whilesmart\Organizations\Events\OrganizationUpdatedEvent;
 use Whilesmart\Organizations\Models\Organization;
 use Whilesmart\Roles\Models\Role;
@@ -200,6 +201,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     public function test_delete_organization()
     {
+        Event::fake();
+
         $user = $this->createUser();
         $this->actingAs($user);
 
@@ -217,6 +220,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
         $this->assertDatabaseMissing('organizations', [
             'id' => $organization->id,
         ]);
+
+        Event::assertDispatched(OrganizationDeletedEvent::class);
     }
 
     public function test_admin_can_add_member_to_organization()
@@ -485,8 +490,11 @@ class TestCase extends \Orchestra\Testbench\TestCase
         Role::create(['name' => 'admin', 'slug' => 'admin']);
         Role::create(['name' => 'member', 'slug' => 'member']);
         config(['organizations.user_model' => User::class]);
-        // config(['organizations.route_middleware' => []]); // does not work. Using bash script in actions file for now
+    }
 
+    protected function getEnvironmentSetUp($app): void
+    {
+        $app['config']->set('organizations.route_middleware', []);
     }
 
     /**
@@ -513,6 +521,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
         return [
             'Whilesmart\OwnerAccess\OwnerAccessServiceProvider',
             'Whilesmart\Organizations\OrganizationsServiceProvider',
+            'Whilesmart\Roles\RolesServiceProvider',
         ];
     }
 }


### PR DESCRIPTION
Applications currently have to copy package routes or controllers to adapt organization behavior. This preserves package-owned routes while exposing stable extension points, completes deletion lifecycle events, and releases them as 1.2.0.